### PR TITLE
Added `kmod-usb-serial` to installed packages

### DIFF
--- a/tutorials/custom-setup-on-turris.md
+++ b/tutorials/custom-setup-on-turris.md
@@ -20,7 +20,7 @@ opkg update
 ### Step 2: Install the driver for the **BigClown Radio Dongle** and **BigClown Core module**:
 
 ```text
-opkg install kmod-usb-serial-ftdi kmod-usb-acm
+opkg install kmod-usb-serial-ftdi kmod-usb-acm kmod-usb-serial
 insmod ftdi_sio
 insmod cdc_acm
 ```


### PR DESCRIPTION
When I followed this tutorial to make things work on my Turris Mox everything was successful but the device `/dev/ttyUSBx` wasn't created. When using `bcg` with `/dev/bus/usb/00x/00x` the `bcg` didn't show any errors but it didn't work either.
Installing additionally `kmod-usb-serial` and restarting solved everything.